### PR TITLE
Sfd5311/add bulk pipeline manifest

### DIFF
--- a/bulk-atac-seq-pipeline-manifest.json
+++ b/bulk-atac-seq-pipeline-manifest.json
@@ -1,0 +1,46 @@
+[
+	{
+		"pattern": "alignment_qc\\.json",
+		"description": "Alignment quality control metrics, in JSON format",
+		"edam_ontology_term": "EDAM_1.24.format_3464"
+	},
+	{
+		"pattern": "(?P<filename>.*)_fastqc\\.html",
+		"description": "FastQC report for {filename}.fastq, HTML version",
+		"edam_ontology_term": "EDAM_1.24.format_2331"
+	},
+	{
+		"pattern": "(?P<filename>.*)_fastqc\\.zip",
+		"description": "FastQC report for {filename}.fastq, zip version",
+		"edam_ontology_term": "EDAM_1.24.format_2333"
+	},
+	{
+		"pattern": "rmsk\\.bam",
+		"description": "Aligned reads",
+		"edam_ontology_term": "EDAM_1.24.format_2572"
+	},
+    {
+        "pattern": "NA_peaks\\.xls",
+        "description": "Tabular file containing peak data",
+        "edam_ontology_term" : "EDAM_1.24.format_3648"
+
+    },
+    {
+        "pattern": "NA_peaks\\.narrowPeak",
+        "description": "BED6+4 format file which contains peak locations, peak summit, p-value, and q-value",
+        "edam_ontology_term" : "EDAM_1.24.format_3613"
+
+    },
+    {
+        "pattern": "NA_summits\\.bed",
+        "description": "BED file containing summit locations for every peak",
+        "edam_ontology_term" : "EDAM_1.24.format_3003"
+
+    },
+    {
+        "pattern": "NA_model\\.r",
+        "description": "An r script for generating a pdf of model based on data",
+        "edam_ontology_term" : "EDAM_1.25.format_3999"
+
+    }
+]

--- a/bulk-atac-seq-pipeline-manifest.json
+++ b/bulk-atac-seq-pipeline-manifest.json
@@ -37,5 +37,16 @@
         "description": "An r script for generating a pdf of model based on data",
         "edam_ontology_term" : "EDAM_1.25.format_3999"
 
+    },
+    {
+        "pattern": "NA_treat_pileup.bdg",
+        "description": "bedGraph format for treatment sample",
+        "edam_ontology_term" : "EDAM_1.24.format_3583"
+
+    },
+    {
+        "pattern": "NA_control_lambda\\.bdg",
+        "description": "bedGraph format for input sample",
+        "edam_ontology_term" : "EDAM_1.24.format_3583"
     }
 ]

--- a/bulk-atac-seq-pipeline-manifest.json
+++ b/bulk-atac-seq-pipeline-manifest.json
@@ -14,11 +14,6 @@
 		"description": "FastQC report for {filename}.fastq, zip version",
 		"edam_ontology_term": "EDAM_1.24.format_2333"
 	},
-	{
-		"pattern": "rmsk\\.bam",
-		"description": "Aligned reads",
-		"edam_ontology_term": "EDAM_1.24.format_2572"
-	},
     {
         "pattern": "NA_peaks\\.xls",
         "description": "Tabular file containing peak data",


### PR DESCRIPTION
@mruffalo For now I've not added the bed graphs output to the manifest, as it doesn't appear to be present in the bulk ATAC datasets I was looking at, but this should cover all of the outputs that are actually present.