### PR TITLE
Reintroducing metadata file argument to CWL steps

### DIFF
--- a/bin/add_barcodes_to_reads.py
+++ b/bin/add_barcodes_to_reads.py
@@ -87,6 +87,7 @@ def main(
     )
 
     all_fastqs_list = list(all_fastqs)
+    print(all_fastqs_list)
 
     metadata_file = metadata_file if metadata_file else find_metadata_file(orig_fastq_dir[0])
 

--- a/sc_atac_seq_prep_process_analyze.cwl
+++ b/sc_atac_seq_prep_process_analyze.cwl
@@ -88,6 +88,7 @@ steps:
      assay: assay
      sequence_directory: sequence_directory
      threads: threads
+     metadata_file: metadata_file
     out:
       - fastqc_dir
       - bam_file

--- a/steps/sc_atac_seq_prep_process_init.cwl
+++ b/steps/sc_atac_seq_prep_process_init.cwl
@@ -12,6 +12,7 @@ inputs:
 
   threads: int?
   exclude_bam: boolean?
+  metadata_file: File?
   
 outputs:
   fastqc_dir:
@@ -107,6 +108,7 @@ steps:
       input_fastq2: concat_fastq/merged_fastq_r2
 
       threads: threads
+      metadata_file: metadata_file
     out:
       - bam_file
       - bam_index


### PR DESCRIPTION
With updates to CWL structure, the optional metadata_file parameter was not being propagated from the top level workflow to the Command Line Tool that needs it